### PR TITLE
프로젝트 분석 및 리팩토링 제안

### DIFF
--- a/CleoAI/Core/Services/AudioRecordingService.swift
+++ b/CleoAI/Core/Services/AudioRecordingService.swift
@@ -136,6 +136,15 @@ class AudioRecordingService: NSObject, ObservableObject {
     }
 }
 
+extension AudioRecordingService: AudioRecordingProviding {
+    var isRecordingPublisher: AnyPublisher<Bool, Never> { $isRecording.eraseToAnyPublisher() }
+    var audioLevelPublisher: AnyPublisher<Float, Never> { $audioLevel.eraseToAnyPublisher() }
+    var recordingTimePublisher: AnyPublisher<TimeInterval, Never> { $recordingTime.eraseToAnyPublisher() }
+    var recordingBufferSizePublisher: AnyPublisher<UInt32, Never> { $recordingBufferSize.eraseToAnyPublisher() }
+    var recordingFormatInfoPublisher: AnyPublisher<String, Never> { $recordingFormatInfo.eraseToAnyPublisher() }
+    var recordingFileSizePublisher: AnyPublisher<Int64, Never> { $recordingFileSize.eraseToAnyPublisher() }
+}
+
 enum AudioRecordingError: LocalizedError {
     case fileCreationFailed(Error)
     case recordingStartFailed(Error)

--- a/CleoAI/Core/Services/ServiceProtocols.swift
+++ b/CleoAI/Core/Services/ServiceProtocols.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Combine
+
+protocol AudioRecordingProviding: AnyObject {
+    var isRecordingPublisher: AnyPublisher<Bool, Never> { get }
+    var audioLevelPublisher: AnyPublisher<Float, Never> { get }
+    var recordingTimePublisher: AnyPublisher<TimeInterval, Never> { get }
+    var recordingBufferSizePublisher: AnyPublisher<UInt32, Never> { get }
+    var recordingFormatInfoPublisher: AnyPublisher<String, Never> { get }
+    var recordingFileSizePublisher: AnyPublisher<Int64, Never> { get }
+    func startRecording() async throws
+    func stopRecording() -> AudioRecording?
+}
+
+protocol TranscriptionProviding: AnyObject {
+    var isTranscribingPublisher: AnyPublisher<Bool, Never> { get }
+    var progressMessagePublisher: AnyPublisher<String, Never> { get }
+    func transcribe(audioRecording: AudioRecording, model: String, language: String) async throws -> TranscriptionResult
+}
+
+protocol NoteSummarizationProviding: AnyObject {
+    func generateSummary(from text: String) async -> String
+    func extractKeywords(from text: String) async -> [String]
+    func categorizeNote(from text: String) async -> NoteCategory
+}
+

--- a/CleoAI/Core/Services/TranscriptionService.swift
+++ b/CleoAI/Core/Services/TranscriptionService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WhisperKit
+import Combine
 
 @MainActor
 class TranscriptionService: ObservableObject {
@@ -60,6 +61,11 @@ class TranscriptionService: ObservableObject {
         progressTimer?.invalidate()
         progressTimer = nil
     }
+}
+
+extension TranscriptionService: TranscriptionProviding {
+    var isTranscribingPublisher: AnyPublisher<Bool, Never> { $isTranscribing.eraseToAnyPublisher() }
+    var progressMessagePublisher: AnyPublisher<String, Never> { $progressMessage.eraseToAnyPublisher() }
 }
 
 enum TranscriptionError: LocalizedError {

--- a/CleoAI/Core/Utils/FileUtils.swift
+++ b/CleoAI/Core/Utils/FileUtils.swift
@@ -1,5 +1,4 @@
 import Foundation
-import UIKit
 
 struct FileUtils {
     

--- a/CleoAI/Features/Recording/ViewModels/RecordingViewModel.swift
+++ b/CleoAI/Features/Recording/ViewModels/RecordingViewModel.swift
@@ -11,35 +11,42 @@ class RecordingViewModel: ObservableObject {
     @Published var recordingFileSize: Int64 = 0
     @Published var errorMessage: String?
     
-    private let audioRecordingService = AudioRecordingService()
+    private let audioService: AudioRecordingProviding
     private var cancellables = Set<AnyCancellable>()
     
-    init() {
+    init(audioService: AudioRecordingProviding = AudioRecordingService()) {
+        self.audioService = audioService
         setupBindings()
     }
     
     private func setupBindings() {
-        audioRecordingService.$isRecording
+        audioService.isRecordingPublisher
+            .receive(on: DispatchQueue.main)
             .assign(to: \.isRecording, on: self)
             .store(in: &cancellables)
         
-        audioRecordingService.$audioLevel
+        audioService.audioLevelPublisher
+            .receive(on: DispatchQueue.main)
             .assign(to: \.audioLevel, on: self)
             .store(in: &cancellables)
         
-        audioRecordingService.$recordingTime
+        audioService.recordingTimePublisher
+            .receive(on: DispatchQueue.main)
             .assign(to: \.recordingTime, on: self)
             .store(in: &cancellables)
         
-        audioRecordingService.$recordingBufferSize
+        audioService.recordingBufferSizePublisher
+            .receive(on: DispatchQueue.main)
             .assign(to: \.recordingBufferSize, on: self)
             .store(in: &cancellables)
         
-        audioRecordingService.$recordingFormatInfo
+        audioService.recordingFormatInfoPublisher
+            .receive(on: DispatchQueue.main)
             .assign(to: \.recordingFormatInfo, on: self)
             .store(in: &cancellables)
         
-        audioRecordingService.$recordingFileSize
+        audioService.recordingFileSizePublisher
+            .receive(on: DispatchQueue.main)
             .assign(to: \.recordingFileSize, on: self)
             .store(in: &cancellables)
     }
@@ -55,7 +62,7 @@ class RecordingViewModel: ObservableObject {
     func startRecording() {
         Task {
             do {
-                try await audioRecordingService.startRecording()
+                try await audioService.startRecording()
                 errorMessage = nil
             } catch {
                 errorMessage = error.localizedDescription
@@ -64,7 +71,7 @@ class RecordingViewModel: ObservableObject {
     }
     
     func stopRecording() -> AudioRecording? {
-        return audioRecordingService.stopRecording()
+        return audioService.stopRecording()
     }
     
     func clearError() {

--- a/CleoAI/Features/Transcription/ViewModels/TranscriptionViewModel.swift
+++ b/CleoAI/Features/Transcription/ViewModels/TranscriptionViewModel.swift
@@ -10,20 +10,27 @@ class TranscriptionViewModel: ObservableObject {
     @Published var selectedLanguage: String = AppConstants.defaultLanguage
     @Published var selectedModelName: String = AppConstants.defaultModel
     
-    private let transcriptionService = TranscriptionService()
-    private let noteSummarizationService = NoteSummarizationService()
+    private let transcriptionService: TranscriptionProviding
+    private let noteSummarizationService: NoteSummarizationProviding
     private var cancellables = Set<AnyCancellable>()
     
-    init() {
+    init(
+        transcriptionService: TranscriptionProviding = TranscriptionService(),
+        noteSummarizationService: NoteSummarizationProviding = NoteSummarizationService()
+    ) {
+        self.transcriptionService = transcriptionService
+        self.noteSummarizationService = noteSummarizationService
         setupBindings()
     }
     
     private func setupBindings() {
-        transcriptionService.$isTranscribing
+        transcriptionService.isTranscribingPublisher
+            .receive(on: DispatchQueue.main)
             .assign(to: \.isTranscribing, on: self)
             .store(in: &cancellables)
         
-        transcriptionService.$progressMessage
+        transcriptionService.progressMessagePublisher
+            .receive(on: DispatchQueue.main)
             .assign(to: \.progressMessage, on: self)
             .store(in: &cancellables)
     }

--- a/CleoAITests/Mocks.swift
+++ b/CleoAITests/Mocks.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Combine
+@testable import CleoAI
+
+final class MockAudioService: AudioRecordingProviding {
+    private let isRecordingSubject = CurrentValueSubject<Bool, Never>(false)
+    private let audioLevelSubject = CurrentValueSubject<Float, Never>(0.0)
+    private let recordingTimeSubject = CurrentValueSubject<TimeInterval, Never>(0.0)
+    private let recordingBufferSizeSubject = CurrentValueSubject<UInt32, Never>(AppConstants.defaultBufferSize)
+    private let recordingFormatInfoSubject = CurrentValueSubject<String, Never>("")
+    private let recordingFileSizeSubject = CurrentValueSubject<Int64, Never>(0)
+    
+    var isRecordingPublisher: AnyPublisher<Bool, Never> { isRecordingSubject.eraseToAnyPublisher() }
+    var audioLevelPublisher: AnyPublisher<Float, Never> { audioLevelSubject.eraseToAnyPublisher() }
+    var recordingTimePublisher: AnyPublisher<TimeInterval, Never> { recordingTimeSubject.eraseToAnyPublisher() }
+    var recordingBufferSizePublisher: AnyPublisher<UInt32, Never> { recordingBufferSizeSubject.eraseToAnyPublisher() }
+    var recordingFormatInfoPublisher: AnyPublisher<String, Never> { recordingFormatInfoSubject.eraseToAnyPublisher() }
+    var recordingFileSizePublisher: AnyPublisher<Int64, Never> { recordingFileSizeSubject.eraseToAnyPublisher() }
+    
+    private(set) var startedCount = 0
+    private(set) var stoppedCount = 0
+    var nextAudioRecording: AudioRecording? = nil
+    
+    func startRecording() async throws {
+        startedCount += 1
+        isRecordingSubject.send(true)
+    }
+    
+    func stopRecording() -> AudioRecording? {
+        stoppedCount += 1
+        isRecordingSubject.send(false)
+        return nextAudioRecording
+    }
+    
+    // Test helpers
+    func send(level: Float, time: TimeInterval, fileSize: Int64, formatInfo: String = "") {
+        audioLevelSubject.send(level)
+        recordingTimeSubject.send(time)
+        recordingFileSizeSubject.send(fileSize)
+        recordingFormatInfoSubject.send(formatInfo)
+    }
+}
+
+final class MockTranscriptionService: TranscriptionProviding {
+    private let isTranscribingSubject = CurrentValueSubject<Bool, Never>(false)
+    private let progressMessageSubject = CurrentValueSubject<String, Never>("")
+    
+    var isTranscribingPublisher: AnyPublisher<Bool, Never> { isTranscribingSubject.eraseToAnyPublisher() }
+    var progressMessagePublisher: AnyPublisher<String, Never> { progressMessageSubject.eraseToAnyPublisher() }
+    
+    var resultToReturn: TranscriptionResult?
+    var errorToThrow: Error?
+    
+    func transcribe(audioRecording: AudioRecording, model: String, language: String) async throws -> TranscriptionResult {
+        isTranscribingSubject.send(true)
+        defer { isTranscribingSubject.send(false) }
+        progressMessageSubject.send("processing...")
+        if let error = errorToThrow { throw error }
+        if let res = resultToReturn { return res }
+        return TranscriptionResult(text: "hello world", language: language, model: model, audioDuration: audioRecording.duration, processingTime: 0.1)
+    }
+}
+
+final class MockNoteSummarizationService: NoteSummarizationProviding {
+    func generateSummary(from text: String) async -> String { "summary:" + text }
+    func extractKeywords(from text: String) async -> [String] { ["kw1", "kw2"] }
+    func categorizeNote(from text: String) async -> NoteCategory { .general }
+}
+

--- a/CleoAITests/RecordingViewModelTests.swift
+++ b/CleoAITests/RecordingViewModelTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import CleoAI
+
+final class RecordingViewModelTests: XCTestCase {
+    func testStartAndStopRecordingUpdatesState() {
+        let mock = MockAudioService()
+        let vm = RecordingViewModel(audioService: mock)
+        
+        XCTAssertFalse(vm.isRecording)
+        vm.startRecording()
+        // Allow async to propagate
+        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        XCTAssertTrue(vm.isRecording)
+        
+        _ = vm.stopRecording()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        XCTAssertFalse(vm.isRecording)
+        
+        XCTAssertEqual(mock.startedCount, 1)
+        XCTAssertEqual(mock.stoppedCount, 1)
+    }
+    
+    func testPublishesAudioMetrics() {
+        let mock = MockAudioService()
+        let vm = RecordingViewModel(audioService: mock)
+        
+        mock.send(level: 0.7, time: 1.2, fileSize: 2048, formatInfo: "44100 Hz, Mono")
+        RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        
+        XCTAssertEqual(vm.audioLevel, 0.7, accuracy: 0.0001)
+        XCTAssertEqual(vm.recordingTime, 1.2, accuracy: 0.0001)
+        XCTAssertEqual(vm.recordingFileSize, 2048)
+        XCTAssertEqual(vm.recordingFormatInfo, "44100 Hz, Mono")
+    }
+}
+

--- a/CleoAITests/TranscriptionViewModelTests.swift
+++ b/CleoAITests/TranscriptionViewModelTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import AVFoundation
+@testable import CleoAI
+
+final class TranscriptionViewModelTests: XCTestCase {
+    func testTranscribeSuccessSetsResult() async throws {
+        let transcriber = MockTranscriptionService()
+        let intel = MockNoteSummarizationService()
+        let vm = TranscriptionViewModel(transcriptionService: transcriber, noteSummarizationService: intel)
+        
+        let dummyURL = URL(fileURLWithPath: "/tmp/a.wav")
+        let recording = AudioRecording(url: dummyURL, duration: 1.0, fileSize: 1000, format: AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 1)!)
+        
+        await vm.transcribe(audioRecording: recording)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        
+        XCTAssertNotNil(vm.transcriptionResult)
+        XCTAssertNil(vm.errorMessage)
+    }
+    
+    func testTranscribeErrorSetsError() async {
+        struct DummyError: Error {}
+        let transcriber = MockTranscriptionService()
+        transcriber.errorToThrow = DummyError()
+        let intel = MockNoteSummarizationService()
+        let vm = TranscriptionViewModel(transcriptionService: transcriber, noteSummarizationService: intel)
+        
+        let dummyURL = URL(fileURLWithPath: "/tmp/a.wav")
+        let recording = AudioRecording(url: dummyURL, duration: 1.0, fileSize: 1000, format: AVAudioFormat(standardFormatWithSampleRate: 44100, channels: 1)!)
+        
+        await vm.transcribe(audioRecording: recording)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        
+        XCTAssertNil(vm.transcriptionResult)
+        XCTAssertNotNil(vm.errorMessage)
+    }
+    
+    func testCreateNoteUsesIntelligence() async {
+        let transcriber = MockTranscriptionService()
+        let intel = MockNoteSummarizationService()
+        let vm = TranscriptionViewModel(transcriptionService: transcriber, noteSummarizationService: intel)
+        
+        let res = TranscriptionResult(text: "hello world from test", language: "en", model: "tiny", audioDuration: 1.0, processingTime: 0.1)
+        let note = await vm.createNote(from: res)
+        
+        XCTAssertEqual(note.summary, "summary:" + res.text)
+        XCTAssertEqual(note.keywords.count, 2)
+        XCTAssertEqual(note.category, .general)
+    }
+}
+


### PR DESCRIPTION
Introduce DI protocols and inject services into ViewModels to enable easier unit testing.

The previous ViewModel implementations directly instantiated concrete service types, making them tightly coupled and difficult to test in isolation. By introducing protocols and injecting dependencies, we can now provide mock service implementations during testing, significantly improving testability and maintainability. This also removes an unused `UIKit` import.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7d2611f-6baf-4778-8a41-22295883e369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7d2611f-6baf-4778-8a41-22295883e369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

