### PR TITLE
feat: Minimize screen brightness during recording for battery saving

### DIFF
--- a/CleoAI.xcodeproj/project.pbxproj
+++ b/CleoAI.xcodeproj/project.pbxproj
@@ -14,22 +14,9 @@
 		878CBE2B2E2B7F3E00BC49C9 /* CleoAI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CleoAI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		878CBE742E2B9FBA00BC49C9 /* Exceptions for "CleoAI" folder in "CleoAI" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Info.plist,
-			);
-			target = 878CBE2A2E2B7F3E00BC49C9 /* CleoAI */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		878CBE2D2E2B7F3E00BC49C9 /* CleoAI */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-				878CBE742E2B9FBA00BC49C9 /* Exceptions for "CleoAI" folder in "CleoAI" target */,
-			);
 			path = CleoAI;
 			sourceTree = "<group>";
 		};
@@ -281,6 +268,7 @@
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음성 인식 및 녹음을 위해 마이크 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = audio;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -310,6 +298,7 @@
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음성 인식 및 녹음을 위해 마이크 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = audio;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -370,7 +359,3 @@
 	};
 	rootObject = 878CBE232E2B7F3E00BC49C9 /* Project object */;
 }
-
-
-
-

--- a/CleoAI.xcodeproj/project.pbxproj
+++ b/CleoAI.xcodeproj/project.pbxproj
@@ -268,7 +268,6 @@
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음성 인식 및 녹음을 위해 마이크 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UIBackgroundModes = audio;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -298,7 +297,6 @@
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "음성 인식 및 녹음을 위해 마이크 접근 권한이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UIBackgroundModes = audio;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/CleoAI/Core/Services/AudioRecordingService.swift
+++ b/CleoAI/Core/Services/AudioRecordingService.swift
@@ -79,17 +79,16 @@ class AudioRecordingService: NSObject, ObservableObject {
                     self.recordingTime = Date().timeIntervalSince(startTime)
                     self.updateRecordingFileSize()
                     
+                    // Check and force brightness every tick (0.1s) to prevent auto-brightness
+                    let currentBrightness = UIScreen.main.brightness
+                    if currentBrightness > 0.015 {
+                        UIScreen.main.brightness = 0.01
+                    }
+                    
                     // Log brightness every 1 second (every 10 ticks)
                     tickCount += 1
                     if tickCount % 10 == 0 {
-                        let currentBrightness = UIScreen.main.brightness
-                        print("💡 [AudioRecording] Current brightness at \(Int(self.recordingTime))s: \(String(format: "%.3f", currentBrightness))")
-                        
-                        // Force brightness back to minimum if it changed (auto-brightness)
-                        if currentBrightness > 0.02 {
-                            print("⚠️ [AudioRecording] Auto-brightness detected (\(String(format: "%.3f", currentBrightness))), forcing back to 0.01")
-                            UIScreen.main.brightness = 0.01
-                        }
+                        print("💡 [AudioRecording] Brightness at \(Int(self.recordingTime))s: \(String(format: "%.3f", currentBrightness)) → forced to 0.01")
                     }
                 }
             }

--- a/CleoAI/Core/Services/AudioRecordingService.swift
+++ b/CleoAI/Core/Services/AudioRecordingService.swift
@@ -72,11 +72,25 @@ class AudioRecordingService: NSObject, ObservableObject {
             }
             recordingStartTime = Date()
             
+            var tickCount = 0
             recordingTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
                 guard let self = self, let startTime = self.recordingStartTime else { return }
                 DispatchQueue.main.async {
                     self.recordingTime = Date().timeIntervalSince(startTime)
                     self.updateRecordingFileSize()
+                    
+                    // Log brightness every 1 second (every 10 ticks)
+                    tickCount += 1
+                    if tickCount % 10 == 0 {
+                        let currentBrightness = UIScreen.main.brightness
+                        print("💡 [AudioRecording] Current brightness at \(Int(self.recordingTime))s: \(String(format: "%.3f", currentBrightness))")
+                        
+                        // Force brightness back to minimum if it changed (auto-brightness)
+                        if currentBrightness > 0.02 {
+                            print("⚠️ [AudioRecording] Auto-brightness detected (\(String(format: "%.3f", currentBrightness))), forcing back to 0.01")
+                            UIScreen.main.brightness = 0.01
+                        }
+                    }
                 }
             }
         } catch {


### PR DESCRIPTION
## 📝 Description

This PR implements automatic screen brightness control during audio recording to save battery while preventing auto-lock.

## 🎯 Features

### 1. **Auto-brightness Control** 💡
- Save original brightness when recording starts
- Set brightness to minimum (0.01) during recording
- Restore original brightness when recording stops

### 2. **Auto-lock Prevention** 🔒
- Disable idle timer during recording to prevent screen from turning off
- Re-enable idle timer after recording stops

### 3. **Auto-brightness Override** 🔧
- Monitor brightness every 0.1 second
- Force brightness back to 0.01 if iOS auto-brightness increases it
- Log brightness status every 1 second for debugging

## 🔍 Technical Details

- Uses `UIScreen.main.brightness` to control screen brightness
- Uses `UIApplication.shared.isIdleTimerDisabled` to prevent auto-lock
- Brightness check runs every 0.1s to immediately counter auto-brightness
- Prevents screen flickering by quickly resetting brightness

## ✅ Testing

Tested on iPhone 16 with successful results:
- Screen dims immediately when recording starts
- Brightness stays at minimum even with auto-brightness enabled
- Original brightness restored after recording stops
- No auto-lock during recording
- Long recording sessions work perfectly

## 🔄 Changes

- `AudioRecordingService.swift`: Add brightness control and idle timer management

## 📊 Benefits

- ✅ Significant battery savings during long recordings
- ✅ Screen stays on without user intervention
- ✅ No recording interruption
- ✅ Better UX with automatic brightness management